### PR TITLE
Compatibility with Reading Schedule

### DIFF
--- a/.source/HarmonyPatches/TimeAssignmentSelector_DrawTimeAssignmentSelectorGrid.cs
+++ b/.source/HarmonyPatches/TimeAssignmentSelector_DrawTimeAssignmentSelectorGrid.cs
@@ -28,6 +28,8 @@ namespace Exosuit
             {
                 rect2.x += rect2.width * 4;
             }
+			if (ModsConfig.IsActive("Safair.ReadingSchedule"))
+				rect2.x += rect2.width;
             DrawTimeAssignmentSelectorFor(rect2, WG_TimeAssignmentDefOf.WG_WorkWithFrame);
         }
         private static void DrawTimeAssignmentSelectorFor(Rect rect, TimeAssignmentDef ta)


### PR DESCRIPTION
Hi!
Here is a small compatibility modification for mod "Reading Schedule".
If this mod is active, then draw the "Pilot" schedule button 1 position to the right.

Reading schedule: https://steamcommunity.com/sharedfiles/filedetails/?id=3367570241
Unfortunately, this mod is not being updated, so it is complicated to contact with author and find src to patch it on his side.

Tests performed:
Without "Reading Schedule"
<img width="1070" height="232" alt="изображение" src="https://github.com/user-attachments/assets/7c80a207-eef0-42d3-a3e0-764770cbd3f6" />
With "Reading Schedule"
<img width="1087" height="280" alt="изображение" src="https://github.com/user-attachments/assets/a2c87c6f-9d98-42f3-a553-d9d8340894e4" />

Thanks!